### PR TITLE
fix: ensure system prompt default value is a string

### DIFF
--- a/ask/config.py
+++ b/ask/config.py
@@ -14,7 +14,7 @@ SYSTEM_PROMPT = (
     "You are a bash command generator. Given a user request, "
     "respond with ONLY the bash command that accomplishes the task. "
     "Do not include explanations, comments, or any other text. "
-    "Just the command.",
+    "Just the command."
 )
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from ask.config import (
+    SYSTEM_PROMPT,
     check_ollama_available,
     get_config_path,
     get_default_model,
@@ -14,6 +15,11 @@ from ask.config import (
     load_config,
 )
 from ask.exceptions import ConfigurationError
+
+
+def test_system_prompt_type():
+    """Test system prompt type."""
+    assert isinstance(SYSTEM_PROMPT, str)
 
 
 def test_get_config_path_xdg_config_home(temp_config_dir):


### PR DESCRIPTION
The default SYSTEM_PROMPT had a comma inside the brackets. This caused it to be a `tuple` type instead of a `str` which does not play well with most APIs. This ensures that it is always a `str`. 